### PR TITLE
vendor: update cilium to get prog types as of Linux kernel 4.17-rc3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -36,7 +36,7 @@
     "pkg/pipeexec",
     "pkg/syncbytes"
   ]
-  revision = "597871e177df8947407c3b2c5c0d1eaa3ad20575"
+  revision = "daf64f9d4ef172e05222000b4893e3eb167c541e"
 
 [[projects]]
   name = "github.com/evalphobia/logrus_fluent"

--- a/vendor/github.com/cilium/cilium/pkg/bpf/bpf.go
+++ b/vendor/github.com/cilium/cilium/pkg/bpf/bpf.go
@@ -50,32 +50,48 @@ const (
 	BPF_MAP_TYPE_ARRAY_OF_MAPS    = 12
 	BPF_MAP_TYPE_HASH_OF_MAPS     = 13
 	BPF_MAP_TYPE_DEVMAP           = 14
+	BPF_MAP_TYPE_SOCKMAP          = 15
+	BPF_MAP_TYPE_CPUMAP           = 16
 
 	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
-	BPF_MAP_CREATE         = 0
-	BPF_MAP_LOOKUP_ELEM    = 1
-	BPF_MAP_UPDATE_ELEM    = 2
-	BPF_MAP_DELETE_ELEM    = 3
-	BPF_MAP_GET_NEXT_KEY   = 4
-	BPF_PROG_LOAD          = 5
-	BPF_OBJ_PIN            = 6
-	BPF_OBJ_GET            = 7
-	BPF_PROG_ATTACH        = 8
-	BPF_PROG_DETACH        = 9
-	BPF_PROG_TEST_RUN      = 10
-	BPF_PROG_GET_NEXT_ID   = 11
-	BPF_MAP_GET_NEXT_ID    = 12
-	BPF_PROG_GET_FD_BY_ID  = 13
-	BPF_MAP_GET_FD_BY_ID   = 14
-	BPF_OBJ_GET_INFO_BY_FD = 15
+	BPF_MAP_CREATE          = 0
+	BPF_MAP_LOOKUP_ELEM     = 1
+	BPF_MAP_UPDATE_ELEM     = 2
+	BPF_MAP_DELETE_ELEM     = 3
+	BPF_MAP_GET_NEXT_KEY    = 4
+	BPF_PROG_LOAD           = 5
+	BPF_OBJ_PIN             = 6
+	BPF_OBJ_GET             = 7
+	BPF_PROG_ATTACH         = 8
+	BPF_PROG_DETACH         = 9
+	BPF_PROG_TEST_RUN       = 10
+	BPF_PROG_GET_NEXT_ID    = 11
+	BPF_MAP_GET_NEXT_ID     = 12
+	BPF_PROG_GET_FD_BY_ID   = 13
+	BPF_MAP_GET_FD_BY_ID    = 14
+	BPF_OBJ_GET_INFO_BY_FD  = 15
+	BPF_PROG_QUERY          = 16
+	BPF_RAW_TRACEPOINT_OPEN = 17
 
 	// Flags for BPF_MAP_UPDATE_ELEM. Must match values from linux/bpf.h
 	BPF_ANY     = 0
 	BPF_NOEXIST = 1
 	BPF_EXIST   = 2
 
+	// Flags for BPF_MAP_CREATE. Must match values from linux/bpf.h
 	BPF_F_NO_PREALLOC   = 1 << 0
 	BPF_F_NO_COMMON_LRU = 1 << 1
+	BPF_F_NUMA_NODE     = 1 << 2
+
+	// Flags for BPF_PROG_QUERY
+	BPF_F_QUERY_EFFECTVE = 1 << 0
+
+	// Flags for accessing BPF object
+	BPF_F_RDONLY = 1 << 3
+	BPF_F_WRONLY = 1 << 4
+
+	// Flag for stack_map, store build_id+offset instead of pointer
+	BPF_F_STACK_BUILD_ID = 1 << 5
 )
 
 // CreateMap creates a Map of type mapType, with key size keySize, a value size of

--- a/vendor/github.com/cilium/cilium/pkg/bpf/endpoint.go
+++ b/vendor/github.com/cilium/cilium/pkg/bpf/endpoint.go
@@ -40,8 +40,9 @@ type EndpointKey struct {
 // GetKeyPtr returns the unsafe pointer to the BPF key
 func (k EndpointKey) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(&k) }
 
-// GetValuePtr returns the unsafe pointer to the BPF value
-func (k EndpointKey) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(&k) }
+// GetValuePtr returns the unsafe pointer to the BPF key for users that
+// use EndpointKey as a value in bpf maps
+func (k *EndpointKey) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
 // NewEndpointKey returns an EndpointKey based on the provided IP address. The
 // address family is automatically detected.

--- a/vendor/github.com/cilium/cilium/pkg/bpf/prog.go
+++ b/vendor/github.com/cilium/cilium/pkg/bpf/prog.go
@@ -40,6 +40,11 @@ const (
 	ProgTypeLwtOut
 	ProgTypeLwtXmit
 	ProgTypeSockOps
+	ProgTypeSkSkb
+	ProgTypeCgroupDevice
+	ProgTypeSkMsg
+	ProgTypeRawTracepoint
+	ProgTypeCgroupSockAddr
 )
 
 func (t ProgType) String() string {
@@ -70,6 +75,16 @@ func (t ProgType) String() string {
 		return "LWT xmit"
 	case ProgTypeSockOps:
 		return "Sock ops"
+	case ProgTypeSkSkb:
+		return "Socket skb"
+	case ProgTypeCgroupDevice:
+		return "Cgroup device"
+	case ProgTypeSkMsg:
+		return "Socket msg"
+	case ProgTypeRawTracepoint:
+		return "Raw tracepoint"
+	case ProgTypeCgroupSockAddr:
+		return "Cgroup sockaddr"
 	}
 
 	return "Unknown"

--- a/vendor/github.com/cilium/cilium/pkg/logging/logfields/logfields.go
+++ b/vendor/github.com/cilium/cilium/pkg/logging/logfields/logfields.go
@@ -47,6 +47,9 @@ const (
 	// Identity is the identifier of a security identity
 	Identity = "identity"
 
+	// OldIdentity is a previously used security identity
+	OldIdentity = "oldIdentity"
+
 	// PolicyRevision is the revision of the policy in the repository or of
 	// the object in question
 	PolicyRevision = "policyRevision"
@@ -62,6 +65,18 @@ const (
 
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
+
+	// IPv4 is an IPv4 address
+	IPv4 = "ipv4"
+
+	// IPv6 is an IPv6 address
+	IPv6 = "ipv6"
+
+	// BuildDuration is the time elapsed to build a BPF program
+	BuildDuration = "buildDuration"
+
+	// StartTime is the start time of an event
+	StartTime = "startTime"
 
 	// V4HealthIP is an address used to contact the cilium-health endpoint
 	V4HealthIP = "v4healthIP.IPv4"


### PR DESCRIPTION
cilium/cilium#3951 added new BPF prog types (and other constants)
available from linux/bpf.h in kernel 4.17-rc3.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>